### PR TITLE
Add `ec2` and `elbv2` resource references

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-03-24T03:18:58Z"
+  build_date: "2024-03-24T04:20:14Z"
   build_hash: ca5ff205b7be9c7fac8f35f8e7a3f6eae22af3ed
   go_version: go1.22.1
   version: v0.32.1-2-gca5ff20-dirty
-api_directory_checksum: 53edcb32e6f2da1ecc65f791466d17cddfeb9bff
+api_directory_checksum: 940601d49f739996f51087e98df9276f7148005c
 api_version: v1alpha1
 aws_sdk_go_version: v1.50.20
 generator_config_info:
-  file_checksum: d58261b46ec108f4945bd0bf078d33a7bf84b7bf
+  file_checksum: 20661a966c58d54fef6ef7ade291825dbd8841e7
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -80,6 +80,21 @@ resources:
           path: Attributes
         compare:
           is_ignored: true
+      SecurityGroups:
+        references:
+          resource: SecurityGroup
+          path: Status.ACKResourceMetadata.ARN
+          service_name: ec2
+      Subnets:
+        references:
+          resource: Subnet
+          path: Status.ACKResourceMetadata.ARN
+          service_name: ec2
+      SubnetMappings.SubnetID:
+        references:
+          resource: Subnet
+          path: Status.ACKResourceMetadata.ARN
+          service_name: ec2
     update_operation:
       custom_method_name: customUpdateLoadBalancer
     renames:
@@ -105,6 +120,10 @@ resources:
         template_path: hooks/load_balancer/sdk_read_many_post_set_output.go.tpl
   Listener:
     fields:
+      DefaultActions.TargetGroupARN:
+        references:
+          resource: TargetGroup
+          path: Status.ACKResourceMetadata.ARN
       LoadBalancerArn:
         is_read_only: false
         is_primary_key: true
@@ -136,6 +155,11 @@ resources:
     fields:
       Name:
         is_required: true
+      VpcId:
+        references:
+          resource: VPC
+          path: Status.VPCID
+          service_name: ec2
     exceptions:
       errors:
         404:
@@ -156,6 +180,13 @@ resources:
     fields:
       ListenerArn:
         is_primary_key: true
+        references:
+          resource: Listener
+          path: Status.ACKResourceMetadata.ARN
+      Actions.targetGroupARN:
+        references:
+          resource: TargetGroup
+          path: Status.ACKResourceMetadata.ARN
       Priority:
         set:
         - ignore: true

--- a/apis/v1alpha1/load_balancer.go
+++ b/apis/v1alpha1/load_balancer.go
@@ -53,7 +53,8 @@ type LoadBalancerSpec struct {
 	// The default is an Internet-facing load balancer.
 	//
 	// You cannot specify a scheme for a Gateway Load Balancer.
-	Scheme *string `json:"scheme,omitempty"`
+	Scheme            *string                                    `json:"scheme,omitempty"`
+	SecurityGroupRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"securityGroupRefs,omitempty"`
 	// [Application Load Balancers and Network Load Balancers] The IDs of the security
 	// groups for the load balancer.
 	SecurityGroups []*string `json:"securityGroups,omitempty"`
@@ -77,7 +78,8 @@ type LoadBalancerSpec struct {
 	//
 	// [Gateway Load Balancers] You can specify subnets from one or more Availability
 	// Zones. You cannot specify Elastic IP addresses for your subnets.
-	SubnetMappings []*SubnetMapping `json:"subnetMappings,omitempty"`
+	SubnetMappings []*SubnetMapping                           `json:"subnetMappings,omitempty"`
+	SubnetRefs     []*ackv1alpha1.AWSResourceReferenceWrapper `json:"subnetRefs,omitempty"`
 	// The IDs of the subnets. You can specify only one subnet per Availability
 	// Zone. You must specify either subnets or subnet mappings, but not both. To
 	// specify an Elastic IP address, specify subnet mappings instead of subnets.

--- a/apis/v1alpha1/rule.go
+++ b/apis/v1alpha1/rule.go
@@ -32,8 +32,8 @@ type RuleSpec struct {
 	// +kubebuilder:validation:Required
 	Conditions []*RuleCondition `json:"conditions"`
 	// The Amazon Resource Name (ARN) of the listener.
-	// +kubebuilder:validation:Required
-	ListenerARN *string `json:"listenerARN"`
+	ListenerARN *string                                  `json:"listenerARN,omitempty"`
+	ListenerRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"listenerRef,omitempty"`
 	// The rule priority. A listener can't have multiple rules with the same priority.
 	// +kubebuilder:validation:Required
 	Priority *int64 `json:"priority"`

--- a/apis/v1alpha1/target_group.go
+++ b/apis/v1alpha1/target_group.go
@@ -125,7 +125,8 @@ type TargetGroupSpec struct {
 	UnhealthyThresholdCount *int64 `json:"unhealthyThresholdCount,omitempty"`
 	// The identifier of the virtual private cloud (VPC). If the target is a Lambda
 	// function, this parameter does not apply. Otherwise, this parameter is required.
-	VPCID *string `json:"vpcID,omitempty"`
+	VPCID  *string                                  `json:"vpcID,omitempty"`
+	VPCRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"vpcRef,omitempty"`
 }
 
 // TargetGroupStatus defines the observed state of TargetGroup

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -67,7 +67,9 @@ type Action struct {
 	// or the query to "#{query}&value=xyz".
 	RedirectConfig *RedirectActionConfig `json:"redirectConfig,omitempty"`
 	TargetGroupARN *string               `json:"targetGroupARN,omitempty"`
-	Type           *string               `json:"type,omitempty"`
+	// Reference field for TargetGroupARN
+	TargetGroupRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"targetGroupRef,omitempty"`
+	Type           *string                                  `json:"type,omitempty"`
 }
 
 // Request parameters to use when integrating with Amazon Cognito to authenticate
@@ -353,6 +355,8 @@ type SubnetMapping struct {
 	IPv6Address        *string `json:"ipv6Address,omitempty"`
 	PrivateIPv4Address *string `json:"privateIPv4Address,omitempty"`
 	SubnetID           *string `json:"subnetID,omitempty"`
+	// Reference field for SubnetID
+	SubnetRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"subnetRef,omitempty"`
 }
 
 // Information about a tag.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -62,6 +62,11 @@ func (in *Action) DeepCopyInto(out *Action) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.TargetGroupRef != nil {
+		in, out := &in.TargetGroupRef, &out.TargetGroupRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Type != nil {
 		in, out := &in.Type, &out.Type
 		*out = new(string)
@@ -871,6 +876,17 @@ func (in *LoadBalancerSpec) DeepCopyInto(out *LoadBalancerSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SecurityGroupRefs != nil {
+		in, out := &in.SecurityGroupRefs, &out.SecurityGroupRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = make([]*string, len(*in))
@@ -889,6 +905,17 @@ func (in *LoadBalancerSpec) DeepCopyInto(out *LoadBalancerSpec) {
 			if (*in)[i] != nil {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(SubnetMapping)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
+	if in.SubnetRefs != nil {
+		in, out := &in.SubnetRefs, &out.SubnetRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
 				(*in).DeepCopyInto(*out)
 			}
 		}
@@ -1476,6 +1503,11 @@ func (in *RuleSpec) DeepCopyInto(out *RuleSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ListenerRef != nil {
+		in, out := &in.ListenerRef, &out.ListenerRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Priority != nil {
 		in, out := &in.Priority, &out.Priority
 		*out = new(int64)
@@ -1671,6 +1703,11 @@ func (in *SubnetMapping) DeepCopyInto(out *SubnetMapping) {
 		in, out := &in.SubnetID, &out.SubnetID
 		*out = new(string)
 		**out = **in
+	}
+	if in.SubnetRef != nil {
+		in, out := &in.SubnetRef, &out.SubnetRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1912,6 +1949,11 @@ func (in *TargetGroupSpec) DeepCopyInto(out *TargetGroupSpec) {
 		in, out := &in.VPCID, &out.VPCID
 		*out = new(string)
 		**out = **in
+	}
+	if in.VPCRef != nil {
+		in, out := &in.VPCRef, &out.VPCRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -60,6 +61,7 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = ec2apitypes.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/crd/bases/elbv2.services.k8s.aws_listeners.yaml
+++ b/config/crd/bases/elbv2.services.k8s.aws_listeners.yaml
@@ -239,6 +239,18 @@ spec:
                       type: object
                     targetGroupARN:
                       type: string
+                    targetGroupRef:
+                      description: Reference field for TargetGroupARN
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      type: object
                     type:
                       type: string
                   type: object

--- a/config/crd/bases/elbv2.services.k8s.aws_loadbalancers.yaml
+++ b/config/crd/bases/elbv2.services.k8s.aws_loadbalancers.yaml
@@ -93,6 +93,23 @@ spec:
 
                   You cannot specify a scheme for a Gateway Load Balancer.
                 type: string
+              securityGroupRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               securityGroups:
                 description: |-
                   [Application Load Balancers and Network Load Balancers] The IDs of the security
@@ -138,6 +155,35 @@ spec:
                       type: string
                     subnetID:
                       type: string
+                    subnetRef:
+                      description: Reference field for SubnetID
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              subnetRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
                   type: object
                 type: array
               subnets:

--- a/config/crd/bases/elbv2.services.k8s.aws_rules.yaml
+++ b/config/crd/bases/elbv2.services.k8s.aws_rules.yaml
@@ -199,6 +199,18 @@ spec:
                       type: object
                     targetGroupARN:
                       type: string
+                    targetGroupRef:
+                      description: Reference field for TargetGroupARN
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      type: object
                     type:
                       type: string
                   type: object
@@ -310,6 +322,21 @@ spec:
               listenerARN:
                 description: The Amazon Resource Name (ARN) of the listener.
                 type: string
+              listenerRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               priority:
                 description: The rule priority. A listener can't have multiple rules
                   with the same priority.
@@ -329,7 +356,6 @@ spec:
             required:
             - actions
             - conditions
-            - listenerARN
             - priority
             type: object
           status:

--- a/config/crd/bases/elbv2.services.k8s.aws_targetgroups.yaml
+++ b/config/crd/bases/elbv2.services.k8s.aws_targetgroups.yaml
@@ -201,6 +201,21 @@ spec:
                   The identifier of the virtual private cloud (VPC). If the target is a Lambda
                   function, this parameter does not apply. Otherwise, this parameter is required.
                 type: string
+              vpcRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
             required:
             - name
             type: object

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -31,6 +31,48 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - vpcs
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - vpcs/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - elbv2.services.k8s.aws
   resources:
   - listeners

--- a/generator.yaml
+++ b/generator.yaml
@@ -80,6 +80,21 @@ resources:
           path: Attributes
         compare:
           is_ignored: true
+      SecurityGroups:
+        references:
+          resource: SecurityGroup
+          path: Status.ACKResourceMetadata.ARN
+          service_name: ec2
+      Subnets:
+        references:
+          resource: Subnet
+          path: Status.ACKResourceMetadata.ARN
+          service_name: ec2
+      SubnetMappings.SubnetID:
+        references:
+          resource: Subnet
+          path: Status.ACKResourceMetadata.ARN
+          service_name: ec2
     update_operation:
       custom_method_name: customUpdateLoadBalancer
     renames:
@@ -105,6 +120,10 @@ resources:
         template_path: hooks/load_balancer/sdk_read_many_post_set_output.go.tpl
   Listener:
     fields:
+      DefaultActions.TargetGroupARN:
+        references:
+          resource: TargetGroup
+          path: Status.ACKResourceMetadata.ARN
       LoadBalancerArn:
         is_read_only: false
         is_primary_key: true
@@ -136,6 +155,11 @@ resources:
     fields:
       Name:
         is_required: true
+      VpcId:
+        references:
+          resource: VPC
+          path: Status.VPCID
+          service_name: ec2
     exceptions:
       errors:
         404:
@@ -156,6 +180,13 @@ resources:
     fields:
       ListenerArn:
         is_primary_key: true
+        references:
+          resource: Listener
+          path: Status.ACKResourceMetadata.ARN
+      Actions.targetGroupARN:
+        references:
+          resource: TargetGroup
+          path: Status.ACKResourceMetadata.ARN
       Priority:
         set:
         - ignore: true

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,12 @@ go 1.21
 toolchain go1.22.0
 
 require (
+	github.com/aws-controllers-k8s/ec2-controller v1.2.4
 	github.com/aws-controllers-k8s/runtime v0.32.0
 	github.com/aws/aws-sdk-go v1.50.20
+	github.com/go-logr/logr v1.4.1
 	github.com/spf13/pflag v1.0.5
+	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
 	sigs.k8s.io/controller-runtime v0.17.2
@@ -21,7 +24,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -66,7 +68,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.29.0 // indirect
 	k8s.io/apiextensions-apiserver v0.29.0 // indirect
 	k8s.io/component-base v0.29.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/aws-controllers-k8s/ec2-controller v1.2.4 h1:lLm/jH4Zmylykuyjo/P8lgHYCdu4do+apX8A34cA0Rk=
+github.com/aws-controllers-k8s/ec2-controller v1.2.4/go.mod h1:d1pRZ8OyXqokbMNmsVcr/gD6ZZ8EJurOK/6jbiV4y14=
 github.com/aws-controllers-k8s/runtime v0.32.0 h1:R0dQs8vRlK50KZ7rgdExqExdlUgFSAzDT8q1HCxc1uc=
 github.com/aws-controllers-k8s/runtime v0.32.0/go.mod h1:6qr9ULkjOHo0fTwEUkE+48IxHqNbHxvvf/9JzGoR8pM=
 github.com/aws/aws-sdk-go v1.50.20 h1:xfAnSDVf/azIWTVQXQODp89bubvCS85r70O3nuQ4dnE=

--- a/helm/crds/elbv2.services.k8s.aws_listeners.yaml
+++ b/helm/crds/elbv2.services.k8s.aws_listeners.yaml
@@ -239,6 +239,18 @@ spec:
                       type: object
                     targetGroupARN:
                       type: string
+                    targetGroupRef:
+                      description: Reference field for TargetGroupARN
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      type: object
                     type:
                       type: string
                   type: object

--- a/helm/crds/elbv2.services.k8s.aws_loadbalancers.yaml
+++ b/helm/crds/elbv2.services.k8s.aws_loadbalancers.yaml
@@ -93,6 +93,23 @@ spec:
 
                   You cannot specify a scheme for a Gateway Load Balancer.
                 type: string
+              securityGroupRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               securityGroups:
                 description: |-
                   [Application Load Balancers and Network Load Balancers] The IDs of the security
@@ -138,6 +155,35 @@ spec:
                       type: string
                     subnetID:
                       type: string
+                    subnetRef:
+                      description: Reference field for SubnetID
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              subnetRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
                   type: object
                 type: array
               subnets:

--- a/helm/crds/elbv2.services.k8s.aws_rules.yaml
+++ b/helm/crds/elbv2.services.k8s.aws_rules.yaml
@@ -199,6 +199,18 @@ spec:
                       type: object
                     targetGroupARN:
                       type: string
+                    targetGroupRef:
+                      description: Reference field for TargetGroupARN
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      type: object
                     type:
                       type: string
                   type: object
@@ -310,6 +322,21 @@ spec:
               listenerARN:
                 description: The Amazon Resource Name (ARN) of the listener.
                 type: string
+              listenerRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               priority:
                 description: The rule priority. A listener can't have multiple rules
                   with the same priority.
@@ -329,7 +356,6 @@ spec:
             required:
             - actions
             - conditions
-            - listenerARN
             - priority
             type: object
           status:

--- a/helm/crds/elbv2.services.k8s.aws_targetgroups.yaml
+++ b/helm/crds/elbv2.services.k8s.aws_targetgroups.yaml
@@ -201,6 +201,21 @@ spec:
                   The identifier of the virtual private cloud (VPC). If the target is a Lambda
                   function, this parameter does not apply. Otherwise, this parameter is required.
                 type: string
+              vpcRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
             required:
             - name
             type: object

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -78,6 +78,48 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - vpcs
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - vpcs/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - elbv2.services.k8s.aws
   resources:
   - listeners

--- a/pkg/resource/load_balancer/delta.go
+++ b/pkg/resource/load_balancer/delta.go
@@ -72,6 +72,9 @@ func newResourceDelta(
 			delta.Add("Spec.Scheme", a.ko.Spec.Scheme, b.ko.Spec.Scheme)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.SecurityGroupRefs, b.ko.Spec.SecurityGroupRefs) {
+		delta.Add("Spec.SecurityGroupRefs", a.ko.Spec.SecurityGroupRefs, b.ko.Spec.SecurityGroupRefs)
+	}
 	if len(a.ko.Spec.SecurityGroups) != len(b.ko.Spec.SecurityGroups) {
 		delta.Add("Spec.SecurityGroups", a.ko.Spec.SecurityGroups, b.ko.Spec.SecurityGroups)
 	} else if len(a.ko.Spec.SecurityGroups) > 0 {
@@ -85,6 +88,9 @@ func newResourceDelta(
 		if !reflect.DeepEqual(a.ko.Spec.SubnetMappings, b.ko.Spec.SubnetMappings) {
 			delta.Add("Spec.SubnetMappings", a.ko.Spec.SubnetMappings, b.ko.Spec.SubnetMappings)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.SubnetRefs, b.ko.Spec.SubnetRefs) {
+		delta.Add("Spec.SubnetRefs", a.ko.Spec.SubnetRefs, b.ko.Spec.SubnetRefs)
 	}
 	if len(a.ko.Spec.Subnets) != len(b.ko.Spec.Subnets) {
 		delta.Add("Spec.Subnets", a.ko.Spec.Subnets, b.ko.Spec.Subnets)

--- a/pkg/resource/load_balancer/references.go
+++ b/pkg/resource/load_balancer/references.go
@@ -17,12 +17,28 @@ package load_balancer
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/elbv2-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
 
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
@@ -30,6 +46,20 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if len(ko.Spec.SecurityGroupRefs) > 0 {
+		ko.Spec.SecurityGroups = nil
+	}
+
+	for f0idx, f0iter := range ko.Spec.SubnetMappings {
+		if f0iter.SubnetRef != nil {
+			ko.Spec.SubnetMappings[f0idx].SubnetID = nil
+		}
+	}
+
+	if len(ko.Spec.SubnetRefs) > 0 {
+		ko.Spec.Subnets = nil
+	}
 
 	return &resource{ko}
 }
@@ -46,11 +76,240 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForSecurityGroups(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForSubnetMappings_SubnetID(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForSubnets(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.LoadBalancer) error {
+
+	if len(ko.Spec.SecurityGroupRefs) > 0 && len(ko.Spec.SecurityGroups) > 0 {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SecurityGroups", "SecurityGroupRefs")
+	}
+
+	for _, f0iter := range ko.Spec.SubnetMappings {
+		if f0iter.SubnetRef != nil && f0iter.SubnetID != nil {
+			return ackerr.ResourceReferenceAndIDNotSupportedFor("SubnetMappings.SubnetID", "SubnetMappings.SubnetRef")
+		}
+	}
+
+	if len(ko.Spec.SubnetRefs) > 0 && len(ko.Spec.Subnets) > 0 {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("Subnets", "SubnetRefs")
+	}
 	return nil
+}
+
+// resolveReferenceForSecurityGroups reads the resource referenced
+// from SecurityGroupRefs field and sets the SecurityGroups
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSecurityGroups(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.LoadBalancer,
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.SecurityGroupRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SecurityGroupRefs")
+			}
+			obj := &ec2apitypes.SecurityGroup{}
+			if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			if ko.Spec.SecurityGroups == nil {
+				ko.Spec.SecurityGroups = make([]*string, 0, 1)
+			}
+			ko.Spec.SecurityGroups = append(ko.Spec.SecurityGroups, (*string)(obj.Status.ACKResourceMetadata.ARN))
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_SecurityGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_SecurityGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.SecurityGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"SecurityGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"SecurityGroup",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
+// resolveReferenceForSubnetMappings_SubnetID reads the resource referenced
+// from SubnetMappings.SubnetRef field and sets the SubnetMappings.SubnetID
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSubnetMappings_SubnetID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.LoadBalancer,
+) (hasReferences bool, err error) {
+	for f0idx, f0iter := range ko.Spec.SubnetMappings {
+		if f0iter.SubnetRef != nil && f0iter.SubnetRef.From != nil {
+			hasReferences = true
+			arr := f0iter.SubnetRef.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SubnetMappings.SubnetRef")
+			}
+			obj := &ec2apitypes.Subnet{}
+			if err := getReferencedResourceState_Subnet(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			ko.Spec.SubnetMappings[f0idx].SubnetID = (*string)(obj.Status.ACKResourceMetadata.ARN)
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Subnet looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Subnet(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.Subnet,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Subnet",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Subnet",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Subnet",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Subnet",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
+// resolveReferenceForSubnets reads the resource referenced
+// from SubnetRefs field and sets the Subnets
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSubnets(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.LoadBalancer,
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.SubnetRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SubnetRefs")
+			}
+			obj := &ec2apitypes.Subnet{}
+			if err := getReferencedResourceState_Subnet(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			if ko.Spec.Subnets == nil {
+				ko.Spec.Subnets = make([]*string, 0, 1)
+			}
+			ko.Spec.Subnets = append(ko.Spec.Subnets, (*string)(obj.Status.ACKResourceMetadata.ARN))
+		}
+	}
+
+	return hasReferences, nil
 }

--- a/pkg/resource/rule/delta.go
+++ b/pkg/resource/rule/delta.go
@@ -64,6 +64,9 @@ func newResourceDelta(
 			delta.Add("Spec.ListenerARN", a.ko.Spec.ListenerARN, b.ko.Spec.ListenerARN)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.ListenerRef, b.ko.Spec.ListenerRef) {
+		delta.Add("Spec.ListenerRef", a.ko.Spec.ListenerRef, b.ko.Spec.ListenerRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Priority, b.ko.Spec.Priority) {
 		delta.Add("Spec.Priority", a.ko.Spec.Priority, b.ko.Spec.Priority)
 	} else if a.ko.Spec.Priority != nil && b.ko.Spec.Priority != nil {

--- a/pkg/resource/rule/references.go
+++ b/pkg/resource/rule/references.go
@@ -17,8 +17,14 @@ package rule
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/elbv2-controller/apis/v1alpha1"
@@ -30,6 +36,16 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	for f0idx, f0iter := range ko.Spec.Actions {
+		if f0iter.TargetGroupRef != nil {
+			ko.Spec.Actions[f0idx].TargetGroupARN = nil
+		}
+	}
+
+	if ko.Spec.ListenerRef != nil {
+		ko.Spec.ListenerARN = nil
+	}
 
 	return &resource{ko}
 }
@@ -46,11 +62,197 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForActions_TargetGroupARN(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForListenerARN(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Rule) error {
+
+	for _, f0iter := range ko.Spec.Actions {
+		if f0iter.TargetGroupRef != nil && f0iter.TargetGroupARN != nil {
+			return ackerr.ResourceReferenceAndIDNotSupportedFor("Actions.TargetGroupARN", "Actions.TargetGroupRef")
+		}
+	}
+
+	if ko.Spec.ListenerRef != nil && ko.Spec.ListenerARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ListenerARN", "ListenerRef")
+	}
+	if ko.Spec.ListenerRef == nil && ko.Spec.ListenerARN == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("ListenerARN", "ListenerRef")
+	}
+	return nil
+}
+
+// resolveReferenceForActions_TargetGroupARN reads the resource referenced
+// from Actions.TargetGroupRef field and sets the Actions.TargetGroupARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForActions_TargetGroupARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Rule,
+) (hasReferences bool, err error) {
+	for f0idx, f0iter := range ko.Spec.Actions {
+		if f0iter.TargetGroupRef != nil && f0iter.TargetGroupRef.From != nil {
+			hasReferences = true
+			arr := f0iter.TargetGroupRef.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: Actions.TargetGroupRef")
+			}
+			obj := &svcapitypes.TargetGroup{}
+			if err := getReferencedResourceState_TargetGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			ko.Spec.Actions[f0idx].TargetGroupARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_TargetGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_TargetGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.TargetGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"TargetGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"TargetGroup",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"TargetGroup",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"TargetGroup",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
+// resolveReferenceForListenerARN reads the resource referenced
+// from ListenerRef field and sets the ListenerARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForListenerARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Rule,
+) (hasReferences bool, err error) {
+	if ko.Spec.ListenerRef != nil && ko.Spec.ListenerRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.ListenerRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ListenerRef")
+		}
+		obj := &svcapitypes.Listener{}
+		if err := getReferencedResourceState_Listener(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.ListenerARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Listener looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Listener(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.Listener,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Listener",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Listener",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Listener",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Listener",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
 	return nil
 }

--- a/pkg/resource/target_group/delta.go
+++ b/pkg/resource/target_group/delta.go
@@ -173,6 +173,9 @@ func newResourceDelta(
 			delta.Add("Spec.VPCID", a.ko.Spec.VPCID, b.ko.Spec.VPCID)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.VPCRef, b.ko.Spec.VPCRef) {
+		delta.Add("Spec.VPCRef", a.ko.Spec.VPCRef, b.ko.Spec.VPCRef)
+	}
 
 	return delta
 }

--- a/pkg/resource/target_group/references.go
+++ b/pkg/resource/target_group/references.go
@@ -17,12 +17,22 @@ package target_group
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/elbv2-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=vpcs,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=vpcs/status,verbs=get;list
 
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
@@ -30,6 +40,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.VPCRef != nil {
+		ko.Spec.VPCID = nil
+	}
 
 	return &resource{ko}
 }
@@ -46,11 +60,103 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForVPCID(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.TargetGroup) error {
+
+	if ko.Spec.VPCRef != nil && ko.Spec.VPCID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("VPCID", "VPCRef")
+	}
+	return nil
+}
+
+// resolveReferenceForVPCID reads the resource referenced
+// from VPCRef field and sets the VPCID
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForVPCID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.TargetGroup,
+) (hasReferences bool, err error) {
+	if ko.Spec.VPCRef != nil && ko.Spec.VPCRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.VPCRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: VPCRef")
+		}
+		obj := &ec2apitypes.VPC{}
+		if err := getReferencedResourceState_VPC(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.VPCID = (*string)(obj.Status.VPCID)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_VPC looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_VPC(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.VPC,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"VPC",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"VPC",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"VPC",
+			namespace, name)
+	}
+	if obj.Status.VPCID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"VPC",
+			namespace, name,
+			"Status.VPCID")
+	}
 	return nil
 }


### PR DESCRIPTION
This patch generates a few resource reference fields that could be used with ec2 and elbv2 controllers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
