### PR TITLE
Add `ForwardConfig` and fix `Subnet`/`SecurityGroup` references

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-03-29T14:25:41Z"
-  build_hash: e8df4d5a4b86dea0e227786c2c3d213e5aeda97a
-  go_version: go1.22.0
-  version: v0.33.0
-api_directory_checksum: 940601d49f739996f51087e98df9276f7148005c
+  build_date: "2024-04-15T00:33:52Z"
+  build_hash: d660ee36fe947607ebea039acd47c35477b4a836
+  go_version: go1.22.1
+  version: v0.33.0-2-gd660ee3
+api_directory_checksum: 877a69abd1d5cb541f1b732cafb4e86e239c5897
 api_version: v1alpha1
 aws_sdk_go_version: v1.50.20
 generator_config_info:
-  file_checksum: 20661a966c58d54fef6ef7ade291825dbd8841e7
+  file_checksum: 19849f617af68d653c2c4e4ebd90d13371a4837e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -83,17 +83,17 @@ resources:
       SecurityGroups:
         references:
           resource: SecurityGroup
-          path: Status.ACKResourceMetadata.ARN
+          path: Status.ID
           service_name: ec2
       Subnets:
         references:
           resource: Subnet
-          path: Status.ACKResourceMetadata.ARN
+          path: Status.SubnetID
           service_name: ec2
       SubnetMappings.SubnetID:
         references:
           resource: Subnet
-          path: Status.ACKResourceMetadata.ARN
+          path: Status.SubnetID
           service_name: ec2
     update_operation:
       custom_method_name: customUpdateLoadBalancer
@@ -121,6 +121,10 @@ resources:
   Listener:
     fields:
       DefaultActions.TargetGroupARN:
+        references:
+          resource: TargetGroup
+          path: Status.ACKResourceMetadata.ARN
+      DefaultActions.ForwardConfig.TargetGroups.TargetGroupARN:
         references:
           resource: TargetGroup
           path: Status.ACKResourceMetadata.ARN

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -386,7 +386,9 @@ type TargetGroupStickinessConfig struct {
 // groups in a forward rule.
 type TargetGroupTuple struct {
 	TargetGroupARN *string `json:"targetGroupARN,omitempty"`
-	Weight         *int64  `json:"weight,omitempty"`
+	// Reference field for TargetGroupARN
+	TargetGroupRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"targetGroupRef,omitempty"`
+	Weight         *int64                                   `json:"weight,omitempty"`
 }
 
 // Information about a target group.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -2042,6 +2042,11 @@ func (in *TargetGroupTuple) DeepCopyInto(out *TargetGroupTuple) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.TargetGroupRef != nil {
+		in, out := &in.TargetGroupRef, &out.TargetGroupRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Weight != nil {
 		in, out := &in.Weight, &out.Weight
 		*out = new(int64)

--- a/config/crd/bases/elbv2.services.k8s.aws_listeners.yaml
+++ b/config/crd/bases/elbv2.services.k8s.aws_listeners.yaml
@@ -183,6 +183,18 @@ spec:
                             properties:
                               targetGroupARN:
                                 type: string
+                              targetGroupRef:
+                                description: Reference field for TargetGroupARN
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
                               weight:
                                 format: int64
                                 type: integer

--- a/config/crd/bases/elbv2.services.k8s.aws_rules.yaml
+++ b/config/crd/bases/elbv2.services.k8s.aws_rules.yaml
@@ -143,6 +143,18 @@ spec:
                             properties:
                               targetGroupARN:
                                 type: string
+                              targetGroupRef:
+                                description: Reference field for TargetGroupARN
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
                               weight:
                                 format: int64
                                 type: integer

--- a/generator.yaml
+++ b/generator.yaml
@@ -83,17 +83,17 @@ resources:
       SecurityGroups:
         references:
           resource: SecurityGroup
-          path: Status.ACKResourceMetadata.ARN
+          path: Status.ID
           service_name: ec2
       Subnets:
         references:
           resource: Subnet
-          path: Status.ACKResourceMetadata.ARN
+          path: Status.SubnetID
           service_name: ec2
       SubnetMappings.SubnetID:
         references:
           resource: Subnet
-          path: Status.ACKResourceMetadata.ARN
+          path: Status.SubnetID
           service_name: ec2
     update_operation:
       custom_method_name: customUpdateLoadBalancer
@@ -121,6 +121,10 @@ resources:
   Listener:
     fields:
       DefaultActions.TargetGroupARN:
+        references:
+          resource: TargetGroup
+          path: Status.ACKResourceMetadata.ARN
+      DefaultActions.ForwardConfig.TargetGroups.TargetGroupARN:
         references:
           resource: TargetGroup
           path: Status.ACKResourceMetadata.ARN

--- a/helm/crds/elbv2.services.k8s.aws_listeners.yaml
+++ b/helm/crds/elbv2.services.k8s.aws_listeners.yaml
@@ -183,6 +183,18 @@ spec:
                             properties:
                               targetGroupARN:
                                 type: string
+                              targetGroupRef:
+                                description: Reference field for TargetGroupARN
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
                               weight:
                                 format: int64
                                 type: integer

--- a/helm/crds/elbv2.services.k8s.aws_rules.yaml
+++ b/helm/crds/elbv2.services.k8s.aws_rules.yaml
@@ -143,6 +143,18 @@ spec:
                             properties:
                               targetGroupARN:
                                 type: string
+                              targetGroupRef:
+                                description: Reference field for TargetGroupARN
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
                               weight:
                                 format: int64
                                 type: integer

--- a/pkg/resource/listener/references.go
+++ b/pkg/resource/listener/references.go
@@ -38,6 +38,16 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 	ko := rm.concreteResource(res).ko.DeepCopy()
 
 	for f0idx, f0iter := range ko.Spec.DefaultActions {
+		if f0iter.ForwardConfig != nil {
+			for f1idx, f1iter := range f0iter.ForwardConfig.TargetGroups {
+				if f1iter.TargetGroupRef != nil {
+					ko.Spec.DefaultActions[f0idx].ForwardConfig.TargetGroups[f1idx].TargetGroupARN = nil
+				}
+			}
+		}
+	}
+
+	for f0idx, f0iter := range ko.Spec.DefaultActions {
 		if f0iter.TargetGroupRef != nil {
 			ko.Spec.DefaultActions[f0idx].TargetGroupARN = nil
 		}
@@ -67,6 +77,12 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForDefaultActions_ForwardConfig_TargetGroups_TargetGroupARN(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForDefaultActions_TargetGroupARN(ctx, apiReader, namespace, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -87,6 +103,16 @@ func (rm *resourceManager) ResolveReferences(
 func validateReferenceFields(ko *svcapitypes.Listener) error {
 
 	for _, f0iter := range ko.Spec.DefaultActions {
+		if f0iter.ForwardConfig != nil {
+			for _, f1iter := range f0iter.ForwardConfig.TargetGroups {
+				if f1iter.TargetGroupRef != nil && f1iter.TargetGroupARN != nil {
+					return ackerr.ResourceReferenceAndIDNotSupportedFor("DefaultActions.ForwardConfig.TargetGroups.TargetGroupARN", "DefaultActions.ForwardConfig.TargetGroups.TargetGroupRef")
+				}
+			}
+		}
+	}
+
+	for _, f0iter := range ko.Spec.DefaultActions {
 		if f0iter.TargetGroupRef != nil && f0iter.TargetGroupARN != nil {
 			return ackerr.ResourceReferenceAndIDNotSupportedFor("DefaultActions.TargetGroupARN", "DefaultActions.TargetGroupRef")
 		}
@@ -101,28 +127,32 @@ func validateReferenceFields(ko *svcapitypes.Listener) error {
 	return nil
 }
 
-// resolveReferenceForDefaultActions_TargetGroupARN reads the resource referenced
-// from DefaultActions.TargetGroupRef field and sets the DefaultActions.TargetGroupARN
+// resolveReferenceForDefaultActions_ForwardConfig_TargetGroups_TargetGroupARN reads the resource referenced
+// from DefaultActions.ForwardConfig.TargetGroups.TargetGroupRef field and sets the DefaultActions.ForwardConfig.TargetGroups.TargetGroupARN
 // from referenced resource. Returns a boolean indicating whether a reference
 // contains references, or an error
-func (rm *resourceManager) resolveReferenceForDefaultActions_TargetGroupARN(
+func (rm *resourceManager) resolveReferenceForDefaultActions_ForwardConfig_TargetGroups_TargetGroupARN(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
 	ko *svcapitypes.Listener,
 ) (hasReferences bool, err error) {
 	for f0idx, f0iter := range ko.Spec.DefaultActions {
-		if f0iter.TargetGroupRef != nil && f0iter.TargetGroupRef.From != nil {
-			hasReferences = true
-			arr := f0iter.TargetGroupRef.From
-			if arr.Name == nil || *arr.Name == "" {
-				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DefaultActions.TargetGroupRef")
+		if f0iter.ForwardConfig != nil {
+			for f1idx, f1iter := range f0iter.ForwardConfig.TargetGroups {
+				if f1iter.TargetGroupRef != nil && f1iter.TargetGroupRef.From != nil {
+					hasReferences = true
+					arr := f1iter.TargetGroupRef.From
+					if arr.Name == nil || *arr.Name == "" {
+						return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DefaultActions.ForwardConfig.TargetGroups.TargetGroupRef")
+					}
+					obj := &svcapitypes.TargetGroup{}
+					if err := getReferencedResourceState_TargetGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+						return hasReferences, err
+					}
+					ko.Spec.DefaultActions[f0idx].ForwardConfig.TargetGroups[f1idx].TargetGroupARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+				}
 			}
-			obj := &svcapitypes.TargetGroup{}
-			if err := getReferencedResourceState_TargetGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-				return hasReferences, err
-			}
-			ko.Spec.DefaultActions[f0idx].TargetGroupARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
 		}
 	}
 
@@ -178,6 +208,34 @@ func getReferencedResourceState_TargetGroup(
 			"Status.ACKResourceMetadata.ARN")
 	}
 	return nil
+}
+
+// resolveReferenceForDefaultActions_TargetGroupARN reads the resource referenced
+// from DefaultActions.TargetGroupRef field and sets the DefaultActions.TargetGroupARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForDefaultActions_TargetGroupARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Listener,
+) (hasReferences bool, err error) {
+	for f0idx, f0iter := range ko.Spec.DefaultActions {
+		if f0iter.TargetGroupRef != nil && f0iter.TargetGroupRef.From != nil {
+			hasReferences = true
+			arr := f0iter.TargetGroupRef.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DefaultActions.TargetGroupRef")
+			}
+			obj := &svcapitypes.TargetGroup{}
+			if err := getReferencedResourceState_TargetGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			ko.Spec.DefaultActions[f0idx].TargetGroupARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+		}
+	}
+
+	return hasReferences, nil
 }
 
 // resolveReferenceForLoadBalancerARN reads the resource referenced

--- a/pkg/resource/load_balancer/references.go
+++ b/pkg/resource/load_balancer/references.go
@@ -146,7 +146,7 @@ func (rm *resourceManager) resolveReferenceForSecurityGroups(
 			if ko.Spec.SecurityGroups == nil {
 				ko.Spec.SecurityGroups = make([]*string, 0, 1)
 			}
-			ko.Spec.SecurityGroups = append(ko.Spec.SecurityGroups, (*string)(obj.Status.ACKResourceMetadata.ARN))
+			ko.Spec.SecurityGroups = append(ko.Spec.SecurityGroups, (*string)(obj.Status.ID))
 		}
 	}
 
@@ -195,11 +195,11 @@ func getReferencedResourceState_SecurityGroup(
 			"SecurityGroup",
 			namespace, name)
 	}
-	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+	if obj.Status.ID == nil {
 		return ackerr.ResourceReferenceMissingTargetFieldFor(
 			"SecurityGroup",
 			namespace, name,
-			"Status.ACKResourceMetadata.ARN")
+			"Status.ID")
 	}
 	return nil
 }
@@ -225,7 +225,7 @@ func (rm *resourceManager) resolveReferenceForSubnetMappings_SubnetID(
 			if err := getReferencedResourceState_Subnet(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
 				return hasReferences, err
 			}
-			ko.Spec.SubnetMappings[f0idx].SubnetID = (*string)(obj.Status.ACKResourceMetadata.ARN)
+			ko.Spec.SubnetMappings[f0idx].SubnetID = (*string)(obj.Status.SubnetID)
 		}
 	}
 
@@ -274,11 +274,11 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name)
 	}
-	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+	if obj.Status.SubnetID == nil {
 		return ackerr.ResourceReferenceMissingTargetFieldFor(
 			"Subnet",
 			namespace, name,
-			"Status.ACKResourceMetadata.ARN")
+			"Status.SubnetID")
 	}
 	return nil
 }
@@ -307,7 +307,7 @@ func (rm *resourceManager) resolveReferenceForSubnets(
 			if ko.Spec.Subnets == nil {
 				ko.Spec.Subnets = make([]*string, 0, 1)
 			}
-			ko.Spec.Subnets = append(ko.Spec.Subnets, (*string)(obj.Status.ACKResourceMetadata.ARN))
+			ko.Spec.Subnets = append(ko.Spec.Subnets, (*string)(obj.Status.SubnetID))
 		}
 	}
 


### PR DESCRIPTION
Description of changes:
- Add `ForwardConfig.TargetGroups.TargetGroupARN` references
- Update `Subnet`/`SecurityGroup` references to point to the resource ID instead of the AWS ARN

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
