### PR TITLE
Tags support for elbv2-controller resources

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -125,6 +125,12 @@ resources:
         code: customPreCompare(delta, a, b)
       sdk_read_many_post_set_output:
         template_path: hooks/load_balancer/sdk_read_many_post_set_output.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/load_balancer/sdk_create_post_set_output.go.tpl
+      sdk_update_pre_build_request:
+        template_path: hooks/load_balancer/sdk_update_pre_build_request.go.tpl
+      sdk_read_many_post_build_request:
+        template_path: hooks/load_balancer/sdk_update_post_build_request.go.tpl
   Listener:
     fields:
       DefaultActions.TargetGroupARN:
@@ -162,6 +168,10 @@ resources:
     hooks:
       sdk_read_many_post_build_request:
         template_path: hooks/listener/sdk_read_many_post_build_request.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/listener/sdk_create_post_set_output.go.tpl
+      sdk_update_pre_build_request:
+        template_path: hooks/target_group/sdk_update_pre_build_request.go.tpl
   TargetGroup:
     fields:
       Name:
@@ -234,3 +244,5 @@ resources:
         template_path: hooks/rule/sdk_update_pre_build_request.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/rule/sdk_read_many_post_set_output.go.tpl
+      sdk_create_post_build_request:
+        template_path: hooks/rule/sdk_create_post_build_request.go.tpl

--- a/pkg/resource/listener/hooks.go
+++ b/pkg/resource/listener/hooks.go
@@ -1,5 +1,18 @@
 package listener
 
+import (
+	"context"
+	"time"
+
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	"github.com/aws-controllers-k8s/elbv2-controller/pkg/resource/tags"
+	svcapitypes "github.com/aws-controllers-k8s/elbv2-controller/apis/v1alpha1"
+)
+
+var (
+	RequeueAfterUpdateDuration = 5 * time.Second
+)
+
 // customCheckRequiredFieldsMissingMethod returns true if there are any fields
 // for the ReadOne Input shape that are required but not present in the
 // resource's Spec or Status.
@@ -7,4 +20,22 @@ func (rm *resourceManager) customCheckRequiredFieldsMissingMethod(
 	r *resource,
 ) bool {
 	return r.Identifiers().ARN() == nil
+}
+
+func (rm *resourceManager) getTags(
+	ctx context.Context,
+	resourceARN  string,
+) ([]*svcapitypes.Tag, error) {
+	return tags.GetResourceTags(ctx, rm.sdkapi, rm.metrics, resourceARN )
+}
+
+func (rm *resourceManager) updateTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.describeTargets")
+	defer func() { exit(err) }()
+	return tags.SyncRecourseTags(ctx, rm.sdkapi, rm.metrics, string(*desired.ko.Status.ACKResourceMetadata.ARN), desired.ko.Spec.Tags, latest.ko.Spec.Tags)
 }

--- a/pkg/resource/load_balancer/sdk.go
+++ b/pkg/resource/load_balancer/sdk.go
@@ -215,6 +215,10 @@ func (rm *resourceManager) sdkFind(
 	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
 		return nil, err
 	}
+	ko.Spec.Tags, err = rm.getTags(ctx, string(*ko.Status.ACKResourceMetadata.ARN))
+	if err != nil {
+		return nil, err
+	}
 
 	return &resource{ko}, nil
 }
@@ -396,6 +400,9 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	if ko.Spec.Tags != nil {
+		return nil, ackrequeue.NeededAfter(fmt.Errorf("Requing due to tags in CREATE"), RequeueAfterUpdateDuration)
+	}
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/tags/sync.go
+++ b/pkg/resource/tags/sync.go
@@ -1,0 +1,166 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tags
+
+import (
+	"context"
+	
+	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+
+	svcapitypes "github.com/aws-controllers-k8s/elbv2-controller/apis/v1alpha1"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
+	svcsdk "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+var (
+	_             = svcapitypes.Tag{}
+	_             = acktags.NewTags()
+	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
+)
+
+type metricsRecorder interface {
+	RecordAPICall(opType string, opID string, err error)
+}
+
+type tagsClient interface {
+	DescribeTags(ctx context.Context, params *svcsdk.DescribeTagsInput, optFuncs ...func(*svcsdk.Options)) (*svcsdk.DescribeTagsOutput, error)
+	AddTags(ctx context.Context, params *svcsdk.AddTagsInput, optFuncs ...func(*svcsdk.Options)) (*svcsdk.AddTagsOutput, error)
+	RemoveTags(ctx context.Context, params *svcsdk.RemoveTagsInput, optFuncs ...func(*svcsdk.Options)) (*svcsdk.RemoveTagsOutput, error)
+}
+
+// GetRecourceTags uses DescribeTags API Call to get the tags of a resource.
+func GetResourceTags(
+	ctx context.Context,
+	client tagsClient,
+	mr metricsRecorder,
+	resourceARN string,
+) ([]*svcapitypes.Tag, error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("GetRecourceTags")
+	defer func() { exit(nil) }()
+
+	describeTagsResponse, err := client.DescribeTags(
+		ctx,
+		&svcsdk.DescribeTagsInput{
+			ResourceArns: []string{resourceARN},
+		},
+	)
+	mr.RecordAPICall("GET", "DescribeTags", err)
+	if err != nil {
+		return nil, err
+	}
+
+	tags := make([]*svcapitypes.Tag, 0, len(describeTagsResponse.TagDescriptions))
+	for _, tagDescription := range describeTagsResponse.TagDescriptions {
+		for _, tagStruct := range tagDescription.Tags {
+			tags = append(tags, &svcapitypes.Tag{
+				Key:   tagStruct.Key,
+				Value: tagStruct.Value,
+			})
+		}
+	}
+	return tags, nil
+}
+
+// SyncResourceTags uses TagResource and UntagResource API Calls to add, remove
+// and update resource tags.
+func SyncRecourseTags(
+	ctx context.Context,
+	client tagsClient,
+	mr metricsRecorder,
+	resourceARN string,
+	currentTags []*svcapitypes.Tag,
+	desiredTags []*svcapitypes.Tag,
+) error {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("SyncRecourseTags")
+	defer func() { exit(err) }()
+
+	addedOrUpdated, removed := computeTagsDelta(currentTags, desiredTags)
+
+	if len(removed) > 0 {
+		_, err = client.RemoveTags(ctx, &svcsdk.RemoveTagsInput{
+			ResourceArns: []string{resourceARN},
+			TagKeys:      removed,
+		})
+		mr.RecordAPICall("UPDATE", "RemoveTags", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(addedOrUpdated) > 0 {
+		_, err = client.AddTags(ctx, &svcsdk.AddTagsInput{
+			ResourceArns: []string{resourceARN},
+			Tags:         sdkTagsFromResourceTags(addedOrUpdated),
+		})
+		mr.RecordAPICall("UPDATE", "AddTags", err)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// computeTagsDelta compares two Tag arrays and return two different list
+// containing the addedOrupdated and removed tags. The removed tags array
+// only contains the tags Keys.
+func computeTagsDelta(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) (addedOrUpdated []*svcapitypes.Tag, removed []string) {
+	var visitedIndexes []string
+mainLoop:
+	for _, aElement := range a {
+		visitedIndexes = append(visitedIndexes, *aElement.Key)
+		for _, bElement := range b {
+			if equalStrings(aElement.Key, bElement.Key) {
+				if !equalStrings(aElement.Value, bElement.Value) {
+					addedOrUpdated = append(addedOrUpdated, bElement)
+				}
+				continue mainLoop
+			}
+		}
+		removed = append(removed, *aElement.Key)
+	}
+	for _, bElement := range b {
+		if !ackutil.InStrings(*bElement.Key, visitedIndexes) {
+			addedOrUpdated = append(addedOrUpdated, bElement)
+		}
+	}
+	return addedOrUpdated, removed
+}
+
+// equal strings
+func equalStrings(a, b *string) bool {
+	if a == nil {
+		return b == nil || *b == ""
+	}
+	return (*a == "" && b == nil) || *a == *b
+}
+
+// svcTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag array.
+func sdkTagsFromResourceTags(rTags []*svcapitypes.Tag) []svcsdktypes.Tag {
+	tags := make([]svcsdktypes.Tag, len(rTags))
+	for i := range rTags {
+		tags[i] = svcsdktypes.Tag{
+			Key:   rTags[i].Key,
+			Value: rTags[i].Value,
+		}
+	}
+	return tags
+}

--- a/templates/hooks/listener/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/listener/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,3 @@
+    if desired.ko.Spec.Tags != nil {
+        return nil, ackrequeue.NeededAfter(fmt.Errorf("Requing due to tags in UPDATE"), RequeueAfterUpdateDuration)
+    }

--- a/templates/hooks/listener/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/listener/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,1 @@
+    Spec.Tags, err = rm.getTags(ctx, string(*ko.Status.ACKResourceMetadata.ARN))

--- a/templates/hooks/listener/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/listener/sdk_update_pre_build_request.go.tpl
@@ -1,0 +1,9 @@
+    if delta.DifferentAt("Spec.Tags") {
+        err = rm.updateTags(ctx, desired, latest)
+        if err != nil {
+            return nil, err
+        }
+    }
+    if !delta.DifferentAt("Spec.Tags") {
+        return desired, nil
+    }

--- a/templates/hooks/load_balancer/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/load_balancer/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,3 @@
+    if desired.ko.Spec.Tags != nil {
+        return nil, ackrequeue.NeededAfter(fmt.Errorf("Requing due to tags in UPDATE"), RequeueAfterUpdateDuration)
+    } 

--- a/templates/hooks/load_balancer/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/load_balancer/sdk_read_many_post_set_output.go.tpl
@@ -1,3 +1,5 @@
 	if err := rm.setResourceAdditionalFields(ctx, ko); err != nil {
 		return nil, err
 	}
+	
+	Spec.Tags, err = rm.getTags(ctx, string(*ko.Status.ACKResourceMetadata.ARN))

--- a/templates/hooks/load_balancer/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/load_balancer/sdk_update_pre_build_request.go.tpl
@@ -1,0 +1,9 @@
+    if delta.DifferentAt("Spec.Tags") {
+        err = rm.updateTags(ctx, desired, latest)
+        if err != nil {
+            return nil, err
+        }
+    }
+    if !delta.DifferentAt("Spec.Tags") {
+        return desired, nil
+    }

--- a/templates/hooks/rule/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/rule/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,3 @@
+    if desired.ko.Spec.Tags != nil {
+        return nil, ackrequeue.NeededAfter(fmt.Errorf("Requing due to tags in UPDATE"), RequeueAfterUpdateDuration)
+    } 

--- a/templates/hooks/rule/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/rule/sdk_read_many_post_set_output.go.tpl
@@ -1,1 +1,2 @@
 	ko.Spec.Priority = priorityFromSDK(resp.Rules[0].Priority)
+	ko.Spec.Tags, err = rm.getTags(ctx, string(*ko.Status.ACKResourceMetadata.ARN))

--- a/templates/hooks/rule/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/rule/sdk_update_pre_build_request.go.tpl
@@ -5,3 +5,13 @@
 	} else if !delta.DifferentExcept("Spec.Priority") {
 		return desired, nil
 	}
+
+    if delta.DifferentAt("Spec.Tags") {
+        err = rm.updateTags(ctx, desired, latest)
+        if err != nil {
+            return nil, err
+        }
+    }
+    if !delta.DifferentAt("Spec.Tags") {
+        return desired, nil
+    }

--- a/templates/hooks/target_group/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/target_group/sdk_create_post_set_output.go.tpl
@@ -1,3 +1,7 @@
 	if ko.Spec.Targets != nil {
 		return nil, ackrequeue.NeededAfter(fmt.Errorf("Requing due to register targets in UPDATE"), RequeueAfterUpdateDuration)
 	}
+	
+	if desired.ko.Spec.Tags != nil {
+        return nil, ackrequeue.NeededAfter(fmt.Errorf("Requing due to tags in UPDATE"), RequeueAfterUpdateDuration)
+    } 

--- a/templates/hooks/target_group/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/target_group/sdk_read_many_post_set_output.go.tpl
@@ -4,3 +4,5 @@
 	}
 
 	rm.setStatusDefaults(ko)
+
+	Spec.Tags, err = rm.getTags(ctx, string(*ko.Status.ACKResourceMetadata.ARN))

--- a/templates/hooks/target_group/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/target_group/sdk_update_pre_build_request.go.tpl
@@ -18,3 +18,11 @@
 	if !delta.DifferentExcept("Spec.Targets") {
 		return desired, nil
 	}
+
+	if delta.DifferentAt("Spec.Priority") {
+		if err = rm.setRulePriority(ctx, desired); err != nil {
+			return nil, err
+		}
+	} else if !delta.DifferentExcept("Spec.Priority") {
+		return desired, nil
+	}

--- a/test/e2e/resources/listener.yaml
+++ b/test/e2e/resources/listener.yaml
@@ -15,3 +15,6 @@ spec:
   loadBalancerARN: $LOAD_BALANCER_ARN
   port: 80
   protocol: "HTTP"
+  tags:
+  - key: tagKey
+    value: tagValue

--- a/test/e2e/resources/load_balancer_tags.yaml
+++ b/test/e2e/resources/load_balancer_tags.yaml
@@ -1,0 +1,12 @@
+apiVersion: elbv2.services.k8s.aws/v1alpha1
+kind: LoadBalancer
+metadata:
+  name: $LOAD_BALANCER_NAME
+spec:
+  name: $LOAD_BALANCER_NAME
+  subnets:
+  - $PUBLIC_SUBNET_1
+  - $PUBLIC_SUBNET_2
+  tags:
+  - key: tagKey
+    value: tagValue

--- a/test/e2e/resources/rule.yaml
+++ b/test/e2e/resources/rule.yaml
@@ -14,3 +14,6 @@ spec:
       values:
       - GET
       - POST
+  tags:
+  - key: "tagKey"
+    value: "tagValue"

--- a/test/e2e/resources/target_group.yaml
+++ b/test/e2e/resources/target_group.yaml
@@ -7,3 +7,6 @@ spec:
   targetType: lambda
   targets:
   - id: $FUNCTION_ARN_1
+  tags:
+  - key: "tagKey"
+    value: "tagValue"

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -68,4 +68,13 @@ class ELBValidator:
     def rule_exists(self, arn):
         return self.get_rule(arn) is not None
     
-
+    def get_tags(self, lb_arn):
+        try:
+            resp = self.elbv2_client.describe_tags(
+                ResourceArns=[lb_arn]
+            )
+            if len(resp['TagDescriptions']) > 0:
+                return resp['TagDescriptions'][0]['Tags']
+            return []
+        except Exception as e:
+            return None

--- a/test/e2e/tests/test_target_groups.py
+++ b/test/e2e/tests/test_target_groups.py
@@ -20,6 +20,7 @@ import time
 import pytest
 from acktest.k8s import resource as k8s
 from acktest.resources import random_suffix_name
+from acktest import tags
 from e2e import CRD_GROUP, CRD_VERSION, load_elbv2_resource, service_marker
 from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e.replacement_values import REPLACEMENT_VALUES
@@ -29,7 +30,8 @@ RESOURCE_PLURAL = "targetgroups"
 
 CREATE_WAIT_AFTER_SECONDS = 30
 UPDATE_WAIT_AFTER_SECONDS = 20
-DELETE_WAIT_AFTER_SECONDS = 10
+DELETE_WAIT_AFTER_SECONDS = 120
+CHECK_STATUS_WAIT_SECONDS = 300
 
 @pytest.fixture(scope="module")
 def simple_target_group(elbv2_client):
@@ -91,6 +93,34 @@ class TestTargetGroups:
         targets = validator.get_registered_targets(resource_arn)
         assert len(targets) == 1
         assert targets[0]["Target"]["Id"] == REPLACEMENT_VALUES["FUNCTION_ARN_1"]
+
+        assert k8s.wait_on_condition(
+            ref,
+            "ACK.ResourceSynced",
+            "True",
+            wait_periods=CHECK_STATUS_WAIT_SECONDS // 10,
+        )
+
+        assert 'status' in cr
+        assert 'ackResourceMetadata' in cr['status']
+        assert 'arn' in cr['status']['ackResourceMetadata']
+        arn = cr['status']['ackResourceMetadata']['arn']
+
+        assert 'tags' in cr['spec']
+        user_tags = cr['spec']['tags']
+
+        response_tags = validator.get_tags(arn)
+
+        tags.assert_ack_system_tags(
+            tags=response_tags,
+        )
+
+        user_tags = [{"Key": d["key"], "Value": d["value"]} for d in user_tags]
+        tags.assert_equal_without_ack_tags(
+            expected=user_tags,
+            actual=response_tags,
+        )
+
         # Update healthyThresholdCount
         updates = {
             "spec": {
@@ -98,6 +128,12 @@ class TestTargetGroups:
                 "targets": [
                     {
                         "id": REPLACEMENT_VALUES["FUNCTION_ARN_2"],
+                    }
+                ],
+                "tags": [
+                    {
+                        "key": "first",
+                        "value": "tag1"
                     }
                 ]
             },
@@ -121,3 +157,25 @@ class TestTargetGroups:
 
         targets = validator.get_registered_targets(resource_arn)
         assert len(targets) == 0
+
+        cr = k8s.get_resource(ref)
+
+        assert 'status' in cr
+        assert 'ackResourceMetadata' in cr['status']
+        assert 'arn' in cr['status']['ackResourceMetadata']
+        arn = cr['status']['ackResourceMetadata']['arn']
+
+        assert 'tags' in cr['spec']
+        user_tags = cr['spec']['tags']
+
+        response_tags = validator.get_tags(arn)
+
+        tags.assert_ack_system_tags(
+            tags=response_tags,
+        )
+
+        user_tags = [{"Key": d["key"], "Value": d["value"]} for d in user_tags]
+        tags.assert_equal_without_ack_tags(
+            expected=user_tags,
+            actual=response_tags,
+        )


### PR DESCRIPTION
Issue #2349

Added update logic of tags in the load_balancer resource for elbv2-controller.
Supported tags for other elbv2-controller resources: listener, rule, and target_group.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
