### PR TITLE
Fix panic when setting tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *~
 .idea
+.vscode
 bin
 build
 .env

--- a/pkg/resource/load_balancer/hooks.go
+++ b/pkg/resource/load_balancer/hooks.go
@@ -212,7 +212,7 @@ func (rm *resourceManager) updateLoadBalancerTags(
 		ctx,
 		rm.sdkapi,
 		rm.metrics,
-		string(*desired.ko.Status.ACKResourceMetadata.ARN),
+		string(*latest.ko.Status.ACKResourceMetadata.ARN),
 		currentTags,
 		desiredTags,
 		convertToOrderedACKTags,


### PR DESCRIPTION
Issue #, if available: 2549

Description of changes:
- Retrieve ARN from latest instead of desired to avoid nil ACKResourceMetadata during adopt-or-create


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
