### PR TITLE
fix(rule): use ruleARN as adoption primary key

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-09-19T16:54:44Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-09-25T18:46:28Z"
+  build_hash: 5bf1e456e1dfc638d47ab492376335f528c0f455
+  go_version: go1.24.5
+  version: v0.52.0-1-g5bf1e45
 api_directory_checksum: c0850c127b1c1c46a7abf233f454e1c7c561a71c
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: cdf7cadf70e31654660514195f4a2f258e7843b8
+  file_checksum: e59ecda70fd052399089af65a682c10fe45d58a5
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -203,9 +203,9 @@ resources:
           output_fields:
             TargetGroupName: Name
   Rule:
+    is_arn_primary_key: true
     fields:
       ListenerArn:
-        is_primary_key: true
         references:
           resource: Listener
           path: Status.ACKResourceMetadata.ARN

--- a/generator.yaml
+++ b/generator.yaml
@@ -203,9 +203,9 @@ resources:
           output_fields:
             TargetGroupName: Name
   Rule:
+    is_arn_primary_key: true
     fields:
       ListenerArn:
-        is_primary_key: true
         references:
           resource: Listener
           path: Status.ACKResourceMetadata.ARN

--- a/pkg/resource/rule/resource.go
+++ b/pkg/resource/rule/resource.go
@@ -87,21 +87,26 @@ func (r *resource) SetStatus(desired acktypes.AWSResource) {
 // SetIdentifiers sets the Spec or Status field that is referenced as the unique
 // resource identifier
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
-	if identifier.NameOrID == "" {
-		return ackerrors.MissingNameIdentifier
+	if r.ko.Status.ACKResourceMetadata == nil {
+		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
-	r.ko.Spec.ListenerARN = &identifier.NameOrID
+	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
 
 	return nil
 }
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	primaryKey, ok := fields["listenerARN"]
+	resourceARN, ok := fields["arn"]
 	if !ok {
-		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: listenerARN"))
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))
 	}
-	r.ko.Spec.ListenerARN = &primaryKey
+
+	if r.ko.Status.ACKResourceMetadata == nil {
+		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	arn := ackv1alpha1.AWSResourceName(resourceARN)
+	r.ko.Status.ACKResourceMetadata.ARN = &arn
 
 	return nil
 }


### PR DESCRIPTION
Issue [#2641](https://github.com/aws-controllers-k8s/community/issues/2641)

Description of changes:
Rule was requiring users to use listenerARN to adopt a resource.
These changes ensure users provide the ruleARN to adopt a Rule

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
