### PR TITLE
Support SecurityGroup/IPAddressType updates

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-02-18T23:48:16Z"
-  build_hash: af61bc1478baf08196fb6e2c81590518a754e45e
-  go_version: go1.25.5
-  version: v0.57.0-9-gaf61bc1
+  build_date: "2026-03-10T22:10:23Z"
+  build_hash: 5ac6c79fbc941c426d8b70cba768820fc9296542
+  go_version: go1.26.0
+  version: v0.58.0
 api_directory_checksum: 55a7358953442001c12f1e7773595ea5c263ba36
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 86479f4102d15c0911cf8b2d5d6a75714fb638ca
+  file_checksum: f943ede4a8a53f3eeb42d66836809653cfd0661b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -88,6 +88,8 @@ resources:
         compare:
           is_ignored: true
       SecurityGroups:
+        late_initialize:
+          skip_incomplete_check: {}
         references:
           resource: SecurityGroup
           path: Status.ID

--- a/generator.yaml
+++ b/generator.yaml
@@ -88,6 +88,8 @@ resources:
         compare:
           is_ignored: true
       SecurityGroups:
+        late_initialize:
+          skip_incomplete_check: {}
         references:
           resource: SecurityGroup
           path: Status.ID

--- a/pkg/resource/load_balancer/hooks.go
+++ b/pkg/resource/load_balancer/hooks.go
@@ -108,8 +108,8 @@ func customPreCompare(
 	}
 }
 
-// customUpdateLoadBalancer is a custom update function that updates the attributes/tags
-// of the load balancer.
+// customUpdateLoadBalancer is a custom update function that updates the
+// mutable properties of the load balancer.
 func (rm *resourceManager) customUpdateLoadBalancer(
 	ctx context.Context,
 	desired *resource,
@@ -128,6 +128,17 @@ func (rm *resourceManager) customUpdateLoadBalancer(
 	}
 	if delta.DifferentAt("Spec.Tags") {
 		if err := rm.updateLoadBalancerTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+	if delta.DifferentAt("Spec.SecurityGroups") {
+		if err := rm.updateLoadBalancerSecurityGroups(ctx, desired); err != nil {
+			return nil, err
+		}
+	}
+
+	if delta.DifferentAt("Spec.IPAddressType") {
+		if err := rm.updateLoadBalancerIPAddressType(ctx, desired); err != nil {
 			return nil, err
 		}
 	}
@@ -179,6 +190,49 @@ func (rm *resourceManager) updateLoadBalancerAttributes(
 		return err
 	}
 	return nil
+}
+
+// updateLoadBalancerSecurityGroups updates the security groups associated with
+// the load balancer by calling the SetSecurityGroups API.
+func (rm *resourceManager) updateLoadBalancerSecurityGroups(
+	ctx context.Context,
+	desired *resource,
+) error {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.updateLoadBalancerSecurityGroups")
+	var err error
+	defer func() { exit(err) }()
+
+	input := &svcsdk.SetSecurityGroupsInput{
+		LoadBalancerArn: (*string)(desired.ko.Status.ACKResourceMetadata.ARN),
+		SecurityGroups:  aws.ToStringSlice(desired.ko.Spec.SecurityGroups),
+	}
+	_, err = rm.sdkapi.SetSecurityGroups(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "SetSecurityGroups", err)
+	return err
+}
+
+// updateLoadBalancerIPAddressType updates the IP address type of the load
+// balancer by calling the SetIpAddressType API.
+func (rm *resourceManager) updateLoadBalancerIPAddressType(
+	ctx context.Context,
+	desired *resource,
+) error {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.updateLoadBalancerIPAddressType")
+	var err error
+	defer func() { exit(err) }()
+
+	if desired.ko.Spec.IPAddressType == nil {
+		return nil
+	}
+	input := &svcsdk.SetIpAddressTypeInput{
+		LoadBalancerArn: (*string)(desired.ko.Status.ACKResourceMetadata.ARN),
+		IpAddressType:   svcsdktypes.IpAddressType(*desired.ko.Spec.IPAddressType),
+	}
+	_, err = rm.sdkapi.SetIpAddressType(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "SetIpAddressType", err)
+	return err
 }
 
 // updateLoadBalancerTags updates the tags of the load balancer.

--- a/pkg/resource/load_balancer/manager.go
+++ b/pkg/resource/load_balancer/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=elbv2.services.k8s.aws,resources=loadbalancers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=elbv2.services.k8s.aws,resources=loadbalancers/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"EnablePrefixForIPv6SourceNAT"}
+var lateInitializeFieldNames = []string{"EnablePrefixForIPv6SourceNAT", "SecurityGroups"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -265,6 +265,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
 	if observedKo.Spec.EnablePrefixForIPv6SourceNAT != nil && latestKo.Spec.EnablePrefixForIPv6SourceNAT == nil {
 		latestKo.Spec.EnablePrefixForIPv6SourceNAT = observedKo.Spec.EnablePrefixForIPv6SourceNAT
+	}
+	if observedKo.Spec.SecurityGroups != nil && latestKo.Spec.SecurityGroups == nil {
+		latestKo.Spec.SecurityGroups = observedKo.Spec.SecurityGroups
 	}
 	return &resource{latestKo}
 }

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -31,6 +31,12 @@ class ELBValidator:
     def get_load_balancer_attributes(self, arn):
         response = self.elbv2_client.describe_load_balancer_attributes(LoadBalancerArn=arn)
         return response['Attributes']
+
+    def get_load_balancer_security_groups(self, name):
+        lb = self.get_load_balancer(name)
+        if lb is None:
+            return None
+        return lb.get('SecurityGroups', [])
     
     def get_listener(self, arn):
         try:

--- a/test/e2e/tests/test_load_balancer.py
+++ b/test/e2e/tests/test_load_balancer.py
@@ -173,7 +173,7 @@ class TestLoadBalancer:
         assert 'ackResourceMetadata' in cr['status']
         assert 'arn' in cr['status']['ackResourceMetadata']
         arn = cr['status']['ackResourceMetadata']['arn']
-        
+
         assert 'tags' in cr['spec']
         user_tags = cr['spec']['tags']
 
@@ -191,3 +191,44 @@ class TestLoadBalancer:
             expected=user_tags,
             actual=actual_tags,
         )
+
+    def test_update_security_groups(self, elbv2_client, simple_load_balancer):
+        (ref, cr, lb_name) = simple_load_balancer
+        assert lb_name is not None
+
+        validator = ELBValidator(elbv2_client)
+        assert validator.load_balancer_exists(lb_name)
+
+        bootstrap_resources = get_bootstrap_resources()
+        bootstrap_sg_id = bootstrap_resources.ACKVPC.security_group.group_id
+
+        # Record the default security groups assigned at creation
+        original_sgs = validator.get_load_balancer_security_groups(lb_name)
+        assert original_sgs is not None
+
+        # Patch the LB to explicitly set the bootstrap security group
+        updates = {
+            "spec": {
+                "securityGroups": [bootstrap_sg_id],
+            },
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        aws_sgs = validator.get_load_balancer_security_groups(lb_name)
+        assert aws_sgs is not None
+        assert len(aws_sgs) == 1
+        assert bootstrap_sg_id in aws_sgs
+
+        # Restore the original security groups
+        updates = {
+            "spec": {
+                "securityGroups": original_sgs,
+            },
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        aws_sgs = validator.get_load_balancer_security_groups(lb_name)
+        assert aws_sgs is not None
+        assert set(aws_sgs) == set(original_sgs)


### PR DESCRIPTION
Issue [#2776](https://github.com/aws-controllers-k8s/community/issues/2776)

Description of changes:
* late initialize LoadBalancer SecurityGroups (AWS sets a default if not defined on create)
* Support updates for LoadBalancer SecurityGroup and IPAddressType 
* e2e test with SecurityGroup update

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
