### PR TITLE
Use Listener ARN instead of load balancer ARN as adoption field

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-03-10T23:56:31Z"
-  build_hash: 5ac6c79fbc941c426d8b70cba768820fc9296542
-  go_version: go1.25.7
-  version: v0.58.0
+  build_date: "2026-03-17T20:48:45Z"
+  build_hash: f0b080577c1ea030a347541b1f7a81843f33c9b6
+  go_version: go1.26.1
+  version: v0.58.0-2-gf0b0805
 api_directory_checksum: 55a7358953442001c12f1e7773595ea5c263ba36
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: f943ede4a8a53f3eeb42d66836809653cfd0661b
+  file_checksum: 62635e8f318a91654839cf1028c41282a292c36b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -130,6 +130,7 @@ resources:
       sdk_read_many_post_set_output:
         template_path: hooks/load_balancer/sdk_read_many_post_set_output.go.tpl
   Listener:
+    is_arn_primary_key: true
     fields:
       DefaultActions.TargetGroupARN:
         references:

--- a/generator.yaml
+++ b/generator.yaml
@@ -130,6 +130,7 @@ resources:
       sdk_read_many_post_set_output:
         template_path: hooks/load_balancer/sdk_read_many_post_set_output.go.tpl
   Listener:
+    is_arn_primary_key: true
     fields:
       DefaultActions.TargetGroupARN:
         references:

--- a/pkg/resource/listener/resource.go
+++ b/pkg/resource/listener/resource.go
@@ -87,21 +87,26 @@ func (r *resource) SetStatus(desired acktypes.AWSResource) {
 // SetIdentifiers sets the Spec or Status field that is referenced as the unique
 // resource identifier
 func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
-	if identifier.NameOrID == "" {
-		return ackerrors.MissingNameIdentifier
+	if r.ko.Status.ACKResourceMetadata == nil {
+		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
-	r.ko.Spec.LoadBalancerARN = &identifier.NameOrID
+	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
 
 	return nil
 }
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	primaryKey, ok := fields["loadBalancerARN"]
+	resourceARN, ok := fields["arn"]
 	if !ok {
-		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: loadBalancerARN"))
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: arn"))
 	}
-	r.ko.Spec.LoadBalancerARN = &primaryKey
+
+	if r.ko.Status.ACKResourceMetadata == nil {
+		r.ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	arn := ackv1alpha1.AWSResourceName(resourceARN)
+	r.ko.Status.ACKResourceMetadata.ARN = &arn
 
 	return nil
 }


### PR DESCRIPTION
Issue #, if available: [2826](https://github.com/aws-controllers-k8s/community/issues/2826)

Description of changes:
PopulateResourceFromAnnotation for the Listener resource incorrectly used loadBalancerARN as the primary adoption field. This resulted in users being unable to adopt Listener resources as the `requiredFieldsMissingFromReadManyInput` would always fail due to ARN of the resource not being set. This PR resolves this by marking Listener with `is_arn_primary_key` in generator.yaml to change the primary adoption field to the ARN of the Listener.

After this change adopting a Listener would use `arn` as adoption field as shown in example below.
```
apiVersion: elbv2.services.k8s.aws/v1alpha1
kind: Listener
metadata:
  name: adopted-listener
  annotations:
    services.k8s.aws/adoption-policy: adopt
    services.k8s.aws/adoption-fields: |
      {
        "arn": "arn:aws:elasticloadbalancing:<region>:<account>:listener/app/<load-balancer-name>/<load-balancer-id>/<listener-id>"
      }
spec:
  defaultActions:
    - type: forward
      forwardConfig:
        targetGroups:
          - targetGroupARN: <target-group-arn>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
