### PR TITLE
Expose IgnoreFieldDrift feature gate in ACK elbv2-controller Helm values

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -197,3 +197,5 @@ featureGates:
   ResourceAdoption: true
   # Enable IAMRoleSelector, a multirole feature, replacing CARM. See https://github.com/aws-controllers-k8s/community/pull/2628
   IAMRoleSelector: false
+  # Enable ResourceAdoption feature/annotation.
+  IgnoreFieldDrift: false


### PR DESCRIPTION
## Summary

Add support for configuring the `IgnoreFieldDrift` feature gate in the ACK controller Helm values.

## Changes

- Added the `IgnoreFieldDrift` feature gate to the Helm values.
- Default value is set to `false` to preserve the current behavior.

## Impact

No functional changes are introduced. The feature remains disabled by default and can be enabled when needed.